### PR TITLE
Add Travis CI configuration to run Jekyll builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+rvm:
+- 2.3.1
+script: "bundle exec jekyll build"


### PR DESCRIPTION
Adds a Travis CI configuration to run Jekyll builds so that I can see any log messages that are produced.