### PR TITLE
Replace Twitter with LinkedIn

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,11 +3,11 @@ title: Joshua Scharf
 subtitle: A developer with an eye for design
 email: jscharf@ackroo.com
 description: > # this means to ignore newlines until "baseurl:"
-             Powered by Jekyll and hosted with Github Pages
+             Powered by Jekyll and hosted with Github Pages and Netlify
 baseurl: "" # the subpath of your site, e.g. /blog/
 url: "http://jscharf.github.io" # the base hostname & protocol for your site
-twitter_username: hogwashjosh
 github_username:  jscharf
+linkedin_username: joshscharf
 
 # Build settings
 markdown: kramdown

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,6 +26,24 @@
           </li>
           {% endif %}
 
+          {% if site.linkedin_username %}
+          <li>
+            <a href="https://www.linkedin.com/in/{{ site.linkedin_username }}">
+              <span class="icon  icon--linkedin">
+                <svg viewBox="0 50 512 512" >
+                  <path fill="#828282" d="M150.65,100.682c0,27.992-22.508,50.683-50.273,50.683c-27.765,0-50.273-22.691-50.273-50.683
+                  C50.104,72.691,72.612,50,100.377,50C128.143,50,150.65,72.691,150.65,100.682z M143.294,187.333H58.277V462h85.017V187.333z
+                  M279.195,187.333h-81.541V462h81.541c0,0,0-101.877,0-144.181c0-38.624,17.779-61.615,51.807-61.615
+                  c31.268,0,46.289,22.071,46.289,61.615c0,39.545,0,144.181,0,144.181h84.605c0,0,0-100.344,0-173.915
+                  s-41.689-109.131-99.934-109.131s-82.768,45.369-82.768,45.369V187.333z"/>
+                </svg>
+              </span>
+
+              <span class="username">{{ site.linkedin_username }}</span>
+            </a>
+          </li>
+          {% endif %}
+
           {% if site.twitter_username %}
           <li>
             <a href="https://twitter.com/{{ site.twitter_username }}">


### PR DESCRIPTION
This change replaces the Twitter link in the footer with a LinkedIn icon and link. 